### PR TITLE
Update CLI to 2.5.5, Python to 3.7.2, and switch from Jessie to Stretch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM python:3.6.7-jessie
+FROM python:3.7.2-stretch
 
-ARG CLI_VERSION=2.5.2
+ARG CLI_VERSION=2.5.5
 ARG BUILD_DATE
 ARG VCS_REF
 


### PR DESCRIPTION
CLI 2.5.5 was just released so updating to that.
Took advantage of the opportunity to update Python and Debian at the same time.